### PR TITLE
ft/add benchmarks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -291,4 +291,4 @@ __pycache__/
 .vscode/
 
 # Benchmark artifacts
-BenchmarkDotNet_Artifacts/
+BenchmarkDotNet.Artifacts/

--- a/.gitignore
+++ b/.gitignore
@@ -289,3 +289,6 @@ __pycache__/
 
 # VSCode folder
 .vscode/
+
+# Benchmark artifacts
+BenchmarkDotNet_Artifacts/

--- a/README.md
+++ b/README.md
@@ -120,51 +120,38 @@ ShortId.Reset();
 
 ## Benchmarks
 
-Measure throughput on your machine with the **BenchmarkDotNet** project in this repo:
+You can measure throughput on your own machine using the **BenchmarkDotNet** project included in this repository:
 
 ```bash
 cd src
 dotnet run -c Release --project shortid.Benchmarks
 ```
 
-Optional quick run: append `-- -j short`. Pass any [BenchmarkDotNet CLI arguments](https://github.com/dotnet/BenchmarkDotNet/blob/master/docs/guide/ConsoleArguments.md) after `--`.
+*(Optional quick run: append `-- -j short`. Pass any [BenchmarkDotNet CLI arguments](https://github.com/dotnet/BenchmarkDotNet/blob/master/docs/guide/ConsoleArguments.md) after `--`.)*
 
-A sample output snapshot is kept in [`benchmarks/SampleResults.md`](benchmarks/SampleResults.md). Absolute timings vary by CPU, OS, and .NET version—compare configurations on the **same** machine.
+Absolute timings will vary depending on your CPU, OS, and .NET version. The findings below were recorded on an Intel Core Ultra 7 265K running .NET 8.
 
----
+### Key Performance Findings
 
-## Choosing length: performance vs collisions
+The library is extremely fast and allocates very little memory (just over 200 bytes per ID), but your configuration choices do impact generation speed:
 
-**Performance:** Fastest generation uses the **shortest** length you can accept and the **smallest** pool—`useNumbers: false` and `useSpecialCharacters: false` (49 letters only). Each extra character and larger alphabet adds a small cost (see benchmarks).
+* **Simplicity is the fastest:** Generating IDs using **only letters** is the absolute fastest method (~25 nanoseconds).
+* **Complexity adds minor overhead:** Adding numbers or special characters makes generation roughly 35% to 70% slower than using letters alone.
+* **Length barely impacts speed:** Increasing your ID length from 8 characters to 15 characters only adds about 12 nanoseconds of execution time.
+* **Sequential mode is heavier:** Generating time-based sequential IDs takes the most time (~75 nanoseconds), which is about 3x slower than a standard random letter ID.
 
-**Random IDs** (default `generateSequential: false`): treat each ID as uniform over \(N^L\) possibilities, where \(L\) is length and \(N\) is the alphabet size:
+### Choosing Your Settings: Speed vs. Uniqueness
 
-| Options | Approx. \(N\) |
-|---------|---------------|
-| Letters only | 49 |
-| + `_` `-` (default-style) | 51 |
-| + digits, no specials | 59 |
-| Digits + specials | 61 |
+When configuring ShortId, you are balancing raw generation speed against the risk of generating the same ID twice (a collision).
 
-For \(M\) IDs drawn independently, the usual birthday approximation for a collision is:
+**For maximum performance (pure speed):**
+Turn off numbers and special characters (`useNumbers: false`, `useSpecialCharacters: false`) and stick to a shorter length (e.g., 8). This is perfect for low-volume applications.
 
-\[
-P(\text{collision}) \approx 1 - \exp\left(-\frac{M(M-1)}{2 N^L}\right)
-\]
+**For high-volume applications (millions of IDs):**
+Do not sacrifice uniqueness for speed. Increase your ID length to **10–14 characters** and include numbers. The performance cost is only a few extra nanoseconds, but it drastically reduces the chance of collisions.
 
-Solve for minimum \(L\) by requiring \(N^L \gg M^2\) (e.g. \(\frac{M^2}{2N^L} &lt; 10^{-3}\) for rough “&lt;0.1%” scale).
-
-**Rule of thumb (random mode, \(N \approx 51\)):**
-
-| Expected IDs \(M\) | Suggested \(L\) (order of magnitude) |
-|-------------------:|-------------------------------------|
-| \(10^4\) | 8 is usually fine |
-| \(10^6\) | 9–10 |
-| \(10^9\) | 13+ |
-
-If you use **only letters** (\(N=49\)), add about one extra character vs the table above for similar risk.
-
-**Sequential IDs** (`generateSequential: true`): the first **6** characters are a time component; only the remaining \(L - 6\) characters are random **per centisecond**. At \(L = 8\) you only have **2** random symbols per time bucket—high collision risk if you generate many IDs in the same centisecond. Prefer **longer** IDs or non-sequential mode for burst traffic.
+**When using Sequential IDs (`generateSequential: true`):**
+Sequential IDs are brilliant for database indexing because the first few characters are based on the current time. However, because the time component takes up space, fewer characters are left for randomness. **Avoid short sequential IDs (e.g., length 8) if you expect massive traffic bursts**, as generating thousands of IDs in the exact same fraction of a second increases collision risk. Prefer longer lengths (12+) for heavy burst traffic.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -37,7 +37,6 @@ dotnet add package shortid
 First, include the **ShortId** namespace in your code:
 ```csharp
 using shortid;
-using shortid.Configuration;
 ```
 
 ### Generate a Random ID
@@ -119,10 +118,60 @@ ShortId.Reset();
 
 ---
 
+## Benchmarks
+
+Measure throughput on your machine with the **BenchmarkDotNet** project in this repo:
+
+```bash
+cd src
+dotnet run -c Release --project shortid.Benchmarks
+```
+
+Optional quick run: append `-- -j short`. Pass any [BenchmarkDotNet CLI arguments](https://github.com/dotnet/BenchmarkDotNet/blob/master/docs/guide/ConsoleArguments.md) after `--`.
+
+A sample output snapshot is kept in [`benchmarks/SampleResults.md`](benchmarks/SampleResults.md). Absolute timings vary by CPU, OS, and .NET version—compare configurations on the **same** machine.
+
+---
+
+## Choosing length: performance vs collisions
+
+**Performance:** Fastest generation uses the **shortest** length you can accept and the **smallest** pool—`useNumbers: false` and `useSpecialCharacters: false` (49 letters only). Each extra character and larger alphabet adds a small cost (see benchmarks).
+
+**Random IDs** (default `generateSequential: false`): treat each ID as uniform over \(N^L\) possibilities, where \(L\) is length and \(N\) is the alphabet size:
+
+| Options | Approx. \(N\) |
+|---------|---------------|
+| Letters only | 49 |
+| + `_` `-` (default-style) | 51 |
+| + digits, no specials | 59 |
+| Digits + specials | 61 |
+
+For \(M\) IDs drawn independently, the usual birthday approximation for a collision is:
+
+\[
+P(\text{collision}) \approx 1 - \exp\left(-\frac{M(M-1)}{2 N^L}\right)
+\]
+
+Solve for minimum \(L\) by requiring \(N^L \gg M^2\) (e.g. \(\frac{M^2}{2N^L} &lt; 10^{-3}\) for rough “&lt;0.1%” scale).
+
+**Rule of thumb (random mode, \(N \approx 51\)):**
+
+| Expected IDs \(M\) | Suggested \(L\) (order of magnitude) |
+|-------------------:|-------------------------------------|
+| \(10^4\) | 8 is usually fine |
+| \(10^6\) | 9–10 |
+| \(10^9\) | 13+ |
+
+If you use **only letters** (\(N=49\)), add about one extra character vs the table above for similar risk.
+
+**Sequential IDs** (`generateSequential: true`): the first **6** characters are a time component; only the remaining \(L - 6\) characters are random **per centisecond**. At \(L = 8\) you only have **2** random symbols per time bucket—high collision risk if you generate many IDs in the same centisecond. Prefer **longer** IDs or non-sequential mode for burst traffic.
+
+---
+
 ## Why Use ShortId? 🌟
 
-- **Flexible Length**: Generate IDs between 8 and 15 characters long.
-- **Customizable**: Use your own character set or exclude special characters.
+- **Flexible Length**: Generate IDs from 8 characters long to whatever length you need.
+- **Customizable**: Use your own character set or exclude certain characters.
 - **Thread-Safe**: Perfect for multi-threaded applications.
 - **Lightweight**: Minimal overhead, maximum performance.
 - **Easy to Use**: Simple API with just a few methods.

--- a/src/shortid.Benchmarks/Program.cs
+++ b/src/shortid.Benchmarks/Program.cs
@@ -1,0 +1,8 @@
+using BenchmarkDotNet.Running;
+using shortid.Benchmarks;
+
+// Non-interactive: BenchmarkSwitcher prompts unless benchmarks are selected.
+var runArgs = args.Any(static a => a is "--filter" or "-f")
+    ? args.ToList()
+    : new List<string> { "--filter", "*" }.Concat(args).ToList();
+BenchmarkSwitcher.FromAssembly(typeof(Program).Assembly).Run(runArgs.ToArray());

--- a/src/shortid.Benchmarks/ShortIdLengthBenchmarks.cs
+++ b/src/shortid.Benchmarks/ShortIdLengthBenchmarks.cs
@@ -1,0 +1,26 @@
+using BenchmarkDotNet.Attributes;
+using shortid;
+
+namespace shortid.Benchmarks;
+
+/// <summary>
+/// Throughput vs length (default-style pool: letters + specials, no numbers).
+/// </summary>
+[MemoryDiagnoser]
+public class ShortIdLengthBenchmarks
+{
+    [Params(8, 9, 10, 11, 12, 13, 14, 15)]
+    public int Length { get; set; }
+
+    private ShortIdOptions _options = null!;
+
+    [GlobalSetup]
+    public void Setup()
+    {
+        ShortId.Reset();
+        _options = new ShortIdOptions(useNumbers: false, useSpecialCharacters: true, length: Length);
+    }
+
+    [Benchmark]
+    public string Generate() => ShortId.Generate(_options);
+}

--- a/src/shortid.Benchmarks/ShortIdOptionsBenchmarks.cs
+++ b/src/shortid.Benchmarks/ShortIdOptionsBenchmarks.cs
@@ -1,0 +1,44 @@
+using BenchmarkDotNet.Attributes;
+using shortid;
+
+namespace shortid.Benchmarks;
+
+/// <summary>
+/// Effect of each option at fixed length 10.
+/// </summary>
+public class ShortIdOptionsBenchmarks
+{
+    private const int FixedLength = 10;
+
+    private ShortIdOptions _lettersOnly = null!;
+    private ShortIdOptions _lettersAndSpecials = null!;
+    private ShortIdOptions _lettersAndNumbers = null!;
+    private ShortIdOptions _fullCharset = null!;
+    private ShortIdOptions _sequentialDefault = null!;
+
+    [GlobalSetup]
+    public void Setup()
+    {
+        ShortId.Reset();
+        _lettersOnly = new ShortIdOptions(false, false, FixedLength);
+        _lettersAndSpecials = new ShortIdOptions(false, true, FixedLength);
+        _lettersAndNumbers = new ShortIdOptions(true, false, FixedLength);
+        _fullCharset = new ShortIdOptions(true, true, FixedLength);
+        _sequentialDefault = new ShortIdOptions(false, true, FixedLength, generateSequential: true);
+    }
+
+    [Benchmark(Baseline = true)]
+    public string LettersOnly() => ShortId.Generate(_lettersOnly);
+
+    [Benchmark]
+    public string LettersAndSpecials() => ShortId.Generate(_lettersAndSpecials);
+
+    [Benchmark]
+    public string LettersAndNumbers() => ShortId.Generate(_lettersAndNumbers);
+
+    [Benchmark]
+    public string FullCharset() => ShortId.Generate(_fullCharset);
+
+    [Benchmark]
+    public string Sequential() => ShortId.Generate(_sequentialDefault);
+}

--- a/src/shortid.Benchmarks/shortid.Benchmarks.csproj
+++ b/src/shortid.Benchmarks/shortid.Benchmarks.csproj
@@ -1,0 +1,16 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net8.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <RootNamespace>shortid.Benchmarks</RootNamespace>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="BenchmarkDotNet" Version="0.14.0" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\shortid\shortid.csproj" />
+  </ItemGroup>
+</Project>

--- a/src/shortid.sln
+++ b/src/shortid.sln
@@ -7,20 +7,54 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "shortid", "shortid/shortid.
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "shortid.Test", "shortid.Test\shortid.Test.csproj", "{E2CA5E27-D080-415C-8AFB-F7779E346B43}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "shortid.Benchmarks", "shortid.Benchmarks\shortid.Benchmarks.csproj", "{92FFE129-0422-490D-AEEF-A36D8E9A8557}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
+		Debug|x64 = Debug|x64
+		Debug|x86 = Debug|x86
 		Release|Any CPU = Release|Any CPU
+		Release|x64 = Release|x64
+		Release|x86 = Release|x86
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
 		{49D7DE0E-34FF-4B17-A411-054479D62B18}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{49D7DE0E-34FF-4B17-A411-054479D62B18}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{49D7DE0E-34FF-4B17-A411-054479D62B18}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{49D7DE0E-34FF-4B17-A411-054479D62B18}.Debug|x64.Build.0 = Debug|Any CPU
+		{49D7DE0E-34FF-4B17-A411-054479D62B18}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{49D7DE0E-34FF-4B17-A411-054479D62B18}.Debug|x86.Build.0 = Debug|Any CPU
 		{49D7DE0E-34FF-4B17-A411-054479D62B18}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{49D7DE0E-34FF-4B17-A411-054479D62B18}.Release|Any CPU.Build.0 = Release|Any CPU
+		{49D7DE0E-34FF-4B17-A411-054479D62B18}.Release|x64.ActiveCfg = Release|Any CPU
+		{49D7DE0E-34FF-4B17-A411-054479D62B18}.Release|x64.Build.0 = Release|Any CPU
+		{49D7DE0E-34FF-4B17-A411-054479D62B18}.Release|x86.ActiveCfg = Release|Any CPU
+		{49D7DE0E-34FF-4B17-A411-054479D62B18}.Release|x86.Build.0 = Release|Any CPU
 		{E2CA5E27-D080-415C-8AFB-F7779E346B43}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{E2CA5E27-D080-415C-8AFB-F7779E346B43}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{E2CA5E27-D080-415C-8AFB-F7779E346B43}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{E2CA5E27-D080-415C-8AFB-F7779E346B43}.Debug|x64.Build.0 = Debug|Any CPU
+		{E2CA5E27-D080-415C-8AFB-F7779E346B43}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{E2CA5E27-D080-415C-8AFB-F7779E346B43}.Debug|x86.Build.0 = Debug|Any CPU
 		{E2CA5E27-D080-415C-8AFB-F7779E346B43}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{E2CA5E27-D080-415C-8AFB-F7779E346B43}.Release|Any CPU.Build.0 = Release|Any CPU
+		{E2CA5E27-D080-415C-8AFB-F7779E346B43}.Release|x64.ActiveCfg = Release|Any CPU
+		{E2CA5E27-D080-415C-8AFB-F7779E346B43}.Release|x64.Build.0 = Release|Any CPU
+		{E2CA5E27-D080-415C-8AFB-F7779E346B43}.Release|x86.ActiveCfg = Release|Any CPU
+		{E2CA5E27-D080-415C-8AFB-F7779E346B43}.Release|x86.Build.0 = Release|Any CPU
+		{92FFE129-0422-490D-AEEF-A36D8E9A8557}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{92FFE129-0422-490D-AEEF-A36D8E9A8557}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{92FFE129-0422-490D-AEEF-A36D8E9A8557}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{92FFE129-0422-490D-AEEF-A36D8E9A8557}.Debug|x64.Build.0 = Debug|Any CPU
+		{92FFE129-0422-490D-AEEF-A36D8E9A8557}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{92FFE129-0422-490D-AEEF-A36D8E9A8557}.Debug|x86.Build.0 = Debug|Any CPU
+		{92FFE129-0422-490D-AEEF-A36D8E9A8557}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{92FFE129-0422-490D-AEEF-A36D8E9A8557}.Release|Any CPU.Build.0 = Release|Any CPU
+		{92FFE129-0422-490D-AEEF-A36D8E9A8557}.Release|x64.ActiveCfg = Release|Any CPU
+		{92FFE129-0422-490D-AEEF-A36D8E9A8557}.Release|x64.Build.0 = Release|Any CPU
+		{92FFE129-0422-490D-AEEF-A36D8E9A8557}.Release|x86.ActiveCfg = Release|Any CPU
+		{92FFE129-0422-490D-AEEF-A36D8E9A8557}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE


### PR DESCRIPTION
Add some benchmarking. 

Raw results
---

BenchmarkDotNet v0.14.0, Windows 11 (10.0.26200.8037)

Intel Core Ultra 7 265K, 1 CPU, 20 logical and 20 physical cores

.NET SDK 10.0.201

  [Host]     : .NET 8.0.25 (8.0.2526.11203), X64 RyuJIT AVX2

  DefaultJob : .NET 8.0.25 (8.0.2526.11203), X64 RyuJIT AVX2

| Method   | Length | Mean     | Error    | StdDev   | Median   | Gen0   | Allocated |
|--------- |------- |---------:|---------:|---------:|---------:|-------:|----------:|
| Generate | 8      | 28.80 ns | 0.601 ns | 1.509 ns | 28.06 ns | 0.0132 |     208 B |
| Generate | 9      | 31.49 ns | 0.490 ns | 0.481 ns | 31.40 ns | 0.0138 |     216 B |
| Generate | 10     | 33.05 ns | 0.306 ns | 0.256 ns | 33.00 ns | 0.0142 |     224 B |
| Generate | 11     | 34.02 ns | 0.269 ns | 0.238 ns | 34.02 ns | 0.0142 |     224 B |
| Generate | 12     | 35.75 ns | 0.526 ns | 0.466 ns | 35.65 ns | 0.0142 |     224 B |
| Generate | 13     | 37.43 ns | 0.452 ns | 0.423 ns | 37.24 ns | 0.0148 |     232 B |
| Generate | 14     | 38.96 ns | 0.369 ns | 0.288 ns | 38.90 ns | 0.0153 |     240 B |
| Generate | 15     | 40.79 ns | 0.449 ns | 0.375 ns | 40.78 ns | 0.0153 |     240 B |

// * Hints *
Outliers
  ShortIdLengthBenchmarks.Generate: Default -> 4 outliers were removed (35.57 ns..36.65 ns)
  ShortIdLengthBenchmarks.Generate: Default -> 1 outlier  was  removed (35.15 ns)
  ShortIdLengthBenchmarks.Generate: Default -> 2 outliers were removed (36.49 ns, 36.66 ns)
  ShortIdLengthBenchmarks.Generate: Default -> 1 outlier  was  removed (36.61 ns)
  ShortIdLengthBenchmarks.Generate: Default -> 1 outlier  was  removed (38.99 ns)
  ShortIdLengthBenchmarks.Generate: Default -> 3 outliers were removed (41.90 ns..42.15 ns)
  ShortIdLengthBenchmarks.Generate: Default -> 2 outliers were removed (43.88 ns, 44.81 ns)

// * Legends *
  Length    : Value of the 'Length' parameter
  Mean      : Arithmetic mean of all measurements
  Error     : Half of 99.9% confidence interval
  StdDev    : Standard deviation of all measurements
  Median    : Value separating the higher half of all measurements (50th percentile)
  Gen0      : GC Generation 0 collects per 1000 operations
  Allocated : Allocated memory per single operation (managed only, inclusive, 1KB = 1024B)
  1 ns      : 1 Nanosecond (0.000000001 sec)

---

BenchmarkDotNet v0.14.0, Windows 11 (10.0.26200.8037)

Intel Core Ultra 7 265K, 1 CPU, 20 logical and 20 physical cores

.NET SDK 10.0.201

  [Host]     : .NET 8.0.25 (8.0.2526.11203), X64 RyuJIT AVX2

  DefaultJob : .NET 8.0.25 (8.0.2526.11203), X64 RyuJIT AVX2

| Method             | Mean     | Error    | StdDev   | Ratio | RatioSD |
|------------------- |---------:|---------:|---------:|------:|--------:|
| LettersOnly        | 25.09 ns | 0.362 ns | 0.321 ns |  1.00 |    0.02 |
| LettersAndSpecials | 33.80 ns | 0.631 ns | 0.590 ns |  1.35 |    0.03 |
| LettersAndNumbers  | 34.34 ns | 0.545 ns | 0.455 ns |  1.37 |    0.02 |
| FullCharset        | 42.99 ns | 0.834 ns | 0.960 ns |  1.71 |    0.04 |
| Sequential         | 75.21 ns | 0.980 ns | 0.869 ns |  3.00 |    0.05 |

// * Hints *
Outliers
  ShortIdOptionsBenchmarks.LettersOnly: Default       -> 1 outlier  was  removed (28.07 ns)
  ShortIdOptionsBenchmarks.LettersAndNumbers: Default -> 2 outliers were removed (38.26 ns, 40.97 ns)
  ShortIdOptionsBenchmarks.FullCharset: Default       -> 1 outlier  was  removed (47.28 ns)
  ShortIdOptionsBenchmarks.Sequential: Default        -> 1 outlier  was  removed (79.53 ns)

// * Legends *
  Mean    : Arithmetic mean of all measurements
  Error   : Half of 99.9% confidence interval
  StdDev  : Standard deviation of all measurements
  Ratio   : Mean of the ratio distribution ([Current]/[Baseline])
  RatioSD : Standard deviation of the ratio distribution ([Current]/[Baseline])
  1 ns    : 1 Nanosecond (0.000000001 sec)
